### PR TITLE
Feature/native session load

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ open files, the cursor-location within them, and other vim-options set while
 creating the session.
 
 `vim-sessionist` is a light-weight wrapper over the session-management commands
-in vim. It also automatically saves your session, when you close Vim, and lets
+in vim. It also automatically saves your session when you close Vim, and lets
 you restore it later.
 
 ## Usage

--- a/autoload/Sessionist.vim
+++ b/autoload/Sessionist.vim
@@ -15,30 +15,46 @@ function! Sessionist#SetSessionPath()
 	endif
 endfunction
 
-" Write session to file
-function! Sessionist#MakeSession()
-	if !exists("g:current_session_path")
-		call Sessionist#SetSessionPath()
-	endif
-	if !exists("g:current_session")
+" Name of current session
+function! Sessionist#CurrentSession()
+	if exists("g:current_session_path") && !exists("g:current_session")
 		call Sessionist#SetSessionName()
 	endif
 
-	execute "mksession! " . g:current_session_path
-	echo g:current_session . " <== Session saved!"
+	if exists("g:current_session")
+		echo g:current_session
+	else
+		echo "No session exists."
+	endif
+endfunction
+
+" List sessions in sessionist directory
+function! Sessionist#ListSessions()
+	let sessions = readdir(g:sessionist_directory, {n -> n =~ '.session$'})
+	for session in sessions
+		echo session
+	endfor
+endfunction
+
+" Write session to file
+function! Sessionist#MakeSession()
+	if !exists("g:current_session_path") || !exists("g:current_session")
+		echo "ERROR: unknown session"
+	else
+		execute "mksession! " . g:current_session_path
+		echo g:current_session . " <== Session saved!"
+	endif
 endfunction
 
 " Load session from file
 function! Sessionist#LoadSession()
-	if !exists("g:current_session_path")
-		call Sessionist#SetSessionPath()
-	endif
-	if !exists("g:current_session")
-		call Sessionist#SetSessionName()
+	if !exists("g:current_session_path") || !exists("g:current_session")
+		echo "ERROR: unknown session"
+	else
+		execute "source " . g:current_session_path
+		echo g:current_session . " <== Session loaded!"
 	endif
 
-	execute "source " . g:current_session_path
-	echo g:current_session . " <== Session loaded!"
 endfunction
 
 " Create new session by entering name
@@ -86,19 +102,6 @@ endfunction
 " Automatically save existing session on quitting Vim (overwrites previous one)
 function! Sessionist#AutoSave()
 	execute "mksession! " . g:sessionist_directory . "/prev.session"
-endfunction
-
-" Name of current session
-function! Sessionist#CurrentSession()
-	if exists("g:current_session_path") && !exists("g:current_session")
-		call Sessionist#SetSessionName()
-	endif
-
-	if exists("g:current_session")
-		echo g:current_session
-	else
-		echo "No session exists."
-	endif
 endfunction
 
 " vim: tabstop=2

--- a/autoload/Sessionist.vim
+++ b/autoload/Sessionist.vim
@@ -39,7 +39,7 @@ endfunction
 " Write session to file
 function! Sessionist#MakeSession()
 	if !exists("g:current_session_path") || !exists("g:current_session")
-		echo "ERROR: unknown session"
+		echoerr "ERROR: unknown session"
 	else
 		execute "mksession! " . g:current_session_path
 		echo g:current_session . " <== Session saved!"
@@ -49,7 +49,7 @@ endfunction
 " Load session from file
 function! Sessionist#LoadSession()
 	if !exists("g:current_session_path") || !exists("g:current_session")
-		echo "ERROR: unknown session"
+		echoerr "ERROR: unknown session"
 	else
 		execute "source " . g:current_session_path
 		echo g:current_session . " <== Session loaded!"
@@ -60,6 +60,7 @@ endfunction
 " Create new session by entering name
 function! Sessionist#NewSession()
 	let session_name = input('Enter session-name: ')
+	redraw
 	if !empty(session_name)
 		let g:current_session = session_name
 		call Sessionist#SetSessionPath()
@@ -81,6 +82,7 @@ endfunction
 " Open existing session
 function! Sessionist#OpenSession()
 	let session_name = input("Enter session-name: ", g:sessionist_directory . "/", "file")
+	redraw
 	if !empty(session_name)
 		let g:current_session_path = session_name
 		call Sessionist#SetSessionName()
@@ -90,7 +92,7 @@ function! Sessionist#OpenSession()
 	endif
 endfunction
 
-" Create new session by entering name
+" Delete session by entering name
 function! Sessionist#DeleteSession()
 	let session_name = input("Delete session: ", g:sessionist_directory . "/", "file")
 	redraw

--- a/autoload/Sessionist.vim
+++ b/autoload/Sessionist.vim
@@ -90,6 +90,17 @@ function! Sessionist#OpenSession()
 	endif
 endfunction
 
+" Create new session by entering name
+function! Sessionist#DeleteSession()
+	let session_name = input("Delete session: ", g:sessionist_directory . "/", "file")
+	redraw
+	if !empty(session_name)
+		delete(session_name)
+	else
+		echo "Empty name entered; not deleting session."
+	endif
+endfunction
+
 " Source previous session
 function! Sessionist#PreviousSession()
 	if v:version >= 703

--- a/autoload/Sessionist.vim
+++ b/autoload/Sessionist.vim
@@ -104,4 +104,12 @@ function! Sessionist#AutoSave()
 	execute "mksession! " . g:sessionist_directory . "/prev.session"
 endfunction
 
+" Recognise loaded session's path
+function! Sessionist#NativeSessionLoad()
+	if exists("v:this_session")
+		let g:current_session_path = v:this_session
+		call Sessionist#SetSessionName()
+	endif
+endfunction
+
 " vim: tabstop=2

--- a/doc/Sessionist.txt
+++ b/doc/Sessionist.txt
@@ -29,7 +29,7 @@ Type the following commands in normal mode:
 * Create a new session: SN
 * Overwrite current session: SS
 * Open a session: SO
-* Restore previous session: SP (requires Vim 7.4+)
+* Restore previous session: SP (requires Vim 7.3+)
 * Get name of current session: SC
 * List existing sessions: SL
 * Delete a session: SD
@@ -43,7 +43,7 @@ Type the following commands in normal mode:
 
 The directory to store session files.
 Default:
-	let g:sessionist_directory = $HOME . '/.vim/.vim-sessions'
+	let g:sessionist_directory = $HOME . '/.vim/.sessions'
 
 --------------------------------------------------------------------------------
 3.2 g:sessionist_new                                          *g:sessionist_new*
@@ -57,7 +57,7 @@ Default:
 
 Command to overwrite the existing session.
 Default:
-	let g:sessionist_save = 'SN'
+	let g:sessionist_save = 'SS'
 
 --------------------------------------------------------------------------------
 3.4 g:sessionist_current                                  *g:sessionist_current*
@@ -83,7 +83,7 @@ Default:
 --------------------------------------------------------------------------------
 3.7 g:sessionist_list                                        *g:sessionist_list*
 
-Command to list existing sessions.
+Command to list existing sessions (in the sessionist directory).
 Default:
 	let g:sessionist_list = 'SL'
 

--- a/plugin/Sessionist.vim
+++ b/plugin/Sessionist.vim
@@ -27,6 +27,7 @@ augroup Sessionist
 	endif
 augroup END
 
+
 " Variables
 
 if !exists("g:sessionist_new")
@@ -37,16 +38,16 @@ if !exists("g:sessionist_save")
 	let g:sessionist_save = 'SS'
 endif
 
-if !exists("g:sessionist_current")
-	let g:sessionist_current = 'SC'
+if !exists("g:sessionist_open")
+	let g:sessionist_open = 'SO'
 endif
 
 if !exists("g:sessionist_previous")
 	let g:sessionist_previous = 'SP'
 endif
 
-if !exists("g:sessionist_open")
-	let g:sessionist_open = 'SO'
+if !exists("g:sessionist_current")
+	let g:sessionist_current = 'SC'
 endif
 
 if !exists("g:sessionist_list")
@@ -57,6 +58,7 @@ if !exists("g:sessionist_delete")
 	let g:sessionist_delete = 'SD'
 endif
 
+
 " Mappings
 
 "" Create new session
@@ -65,14 +67,14 @@ execute 'nnoremap' g:sessionist_new ':call Sessionist#NewSession()<CR>'
 "" Save existing session
 execute 'nnoremap' g:sessionist_save ':call Sessionist#SaveSession()<CR>'
 
-"" Get name of current session
-execute 'nnoremap' g:sessionist_current ':call Sessionist#CurrentSession()<CR>'
+"" Open session
+execute 'nnoremap' g:sessionist_open ':call Sessionist#OpenSession()<CR>'
 
 "" Restore previous session
 execute 'nnoremap' g:sessionist_previous ':call Sessionist#PreviousSession()<CR>'
 
-"" Open session
-execute 'nnoremap' g:sessionist_open ':call Sessionist#OpenSession()<CR>'
+"" Print name of current session
+execute 'nnoremap' g:sessionist_current ':call Sessionist#CurrentSession()<CR>'
 
 "" List sessions
 execute 'nnoremap' g:sessionist_list ':call Sessionist#ListSessions()<CR>'

--- a/plugin/Sessionist.vim
+++ b/plugin/Sessionist.vim
@@ -15,16 +15,14 @@ if !isdirectory(g:sessionist_directory)
 	silent call mkdir(g:sessionist_directory, "p")
 endif
 
-" Recognise natively loaded sessions
-if exists("v:this_session")
-	let g:current_session_path = v:this_session
-	call Sessionist#SetSessionName()
-endif
-
-" Call AutoSave() on quitting Vim (for vim versions >= 7.3)
 augroup Sessionist
+	autocmd!
+
+	" Call NativeSessionLoad() on session load
+	autocmd SessionLoadPost * call Sessionist#NativeSessionLoad()
+
+	" Call AutoSave() on quitting Vim (for vim versions >= 7.3)
 	if v:version >= 703
-		autocmd!
 		autocmd QuitPre * call Sessionist#AutoSave()
 	endif
 augroup END

--- a/plugin/Sessionist.vim
+++ b/plugin/Sessionist.vim
@@ -77,7 +77,7 @@ execute 'nnoremap' g:sessionist_previous ':call Sessionist#PreviousSession()<CR>
 execute 'nnoremap' g:sessionist_open ':call Sessionist#OpenSession()<CR>'
 
 "" List sessions
-execute 'nnoremap' g:sessionist_list ':!ls ' . g:sessionist_directory . '<CR>'
+execute 'nnoremap' g:sessionist_list ':call Sessionist#ListSessions()<CR>'
 
 "" Delete session
 execute 'nnoremap' g:sessionist_delete ':!rm ' . g:sessionist_directory . '/'

--- a/plugin/Sessionist.vim
+++ b/plugin/Sessionist.vim
@@ -15,6 +15,12 @@ if !isdirectory(g:sessionist_directory)
 	silent call mkdir(g:sessionist_directory, "p")
 endif
 
+" Recognise natively loaded sessions
+if exists("v:this_session")
+	let g:current_session_path = v:this_session
+	call Sessionist#SetSessionName()
+endif
+
 " Call AutoSave() on quitting Vim (for vim versions >= 7.3)
 augroup Sessionist
 	if v:version >= 703


### PR DESCRIPTION
Added functionality to detect when a session has been loaded natively by Vim (e.g. using `vim -S some.session`), and use that session information for saving sessions.
This involved adding a new global variable which indicates the full path to the current session, rather than assuming it is in the default vim-sessionist folder. This also meant overhauling the way functions use and interact with these variables.

Some functionality that relied on external commends has also been replaced with functions that call on vim functions, to hopefully allow better cross-platform support.

Also, some documentation was updated to correct a number of minor errors.